### PR TITLE
Make recentering point at window edge optional

### DIFF
--- a/sublimity.el
+++ b/sublimity.el
@@ -76,6 +76,12 @@
 handle scrolling."
   :group 'sublimity)
 
+(defcustom sublimity-recenter-at-window-edge t
+  "when non-nil, sublimity will recenter the point when it moves
+past the window edge"
+  :type 'boolean
+  :group 'sublimity)
+
 ;; + minor mode
 
 (defvar sublimity-auto-hscroll-mode nil)
@@ -172,8 +178,9 @@ handle scrolling."
       (when handle-scroll
         (let (deactivate-mark)
           ;; do vscroll
-          (when (or (< (point) (window-start))
-                    (>= (point) (window-end)))
+          (when (and sublimity-recenter-at-window-edge
+                     (or (< (point) (window-start))
+                         (>= (point) (window-end))))
             (recenter))
           ;; do hscroll
           (when (and sublimity-auto-hscroll-mode


### PR DESCRIPTION
Sublimity mimics the default Emacs behavior when the point reaches the edge of the window. However, it would be nice to have smooth-scrolling behave exactly like Sublime such that the window only scrolls one line at a time when moving the point outside the window.

This leaves the default behavior, but lets you disable the `(recenter)` call so that when someone changes Emacs' scrolling behavior (i.e. `(setq scroll-conservatively 101`) it behaves like you'd expect.

Is this an okay solution?