### PR TITLE
adding css mode explicitly

### DIFF
--- a/sublimity-map.el
+++ b/sublimity-map.el
@@ -66,7 +66,8 @@
 (defcustom sublimity-map-criteria
   '((not (window-minibuffer-p))
     (or (derived-mode-p 'prog-mode)
-        (derived-mode-p 'text-mode))
+        (derived-mode-p 'text-mode)
+        (derived-mode-p 'css-mode))
     (<= (/ sublimity-map-size (window-total-width) 1.0)
         sublimity-map-max-fraction))
   "sexps that must be evaluated to non-nil when creating minimap"


### PR DESCRIPTION
Noticed that in css-mode, map does not appear.

Here's a quick hack to get css to support map views. Dunno if this is the best way of doing it, but wanted to throw this your way to see what you thought.