### PR TITLE
Fix recenter error when displaying buffer from emacsclient

### DIFF
--- a/sublimity.el
+++ b/sublimity.el
@@ -173,7 +173,8 @@
           ;; do vscroll
           (when (or (< (point) (window-start))
                     (>= (point) (window-end)))
-            (recenter))
+            (with-selected-window sublimity--prev-wnd
+              (recenter)))
           ;; do hscroll
           (when (and sublimity-auto-hscroll-mode
                      (or truncate-lines


### PR DESCRIPTION
Encountered the following error when calling emacsclient on
a file which is already open in a buffer which is not
currently displayed:

    *ERROR*: ‘recenter’ing a window that does not display current-buffer.

This commit solves the problem.