### PR TITLE
Trigger scroll animation if point is partially off-screen

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -32,6 +32,8 @@ instead. Thus, to disable horizontal scrolling, set
 =sublimity-auto-hscroll-mode= but not =auto-hscroll-mode= while
 =sublimity-mode= is turned on.
 
+=sublimity-scroll= currently requires an unset/zero =scroll-margin=.
+
 ** Customization
 *** sublimity-scroll (smooth scrolling)
 

--- a/sublimity.el
+++ b/sublimity.el
@@ -173,8 +173,7 @@
       (when handle-scroll
         (let (deactivate-mark)
           ;; do vscroll
-          (when (or (< (point) (window-start))
-                    (>= (point) (window-end)))
+          (when (not (pos-visible-in-window-p))
             (recenter))
           ;; do hscroll
           (when (and sublimity-auto-hscroll-mode


### PR DESCRIPTION
Addresses #55 for `C-n` at bottom of a window showing part of a line of text. Does not take `scroll-margin` into account.