### PR TITLE
Option to slow down smooth scrolling animation for fast computers

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -60,6 +60,12 @@ With the configuration above, scroll is divided into 15 steps again,
 but the last *10* steps are all 1 line scrolls. this looks smoother
 but perhaps more annoying for some users.
 
+For fast computers where the smooth scrolling effect happens too
+quickly, you can configure a small delay (in seconds) that occurs
+between scroll steps:
+
+: (setq sublimity-scroll-vertical-frame-delay 0.01)
+
 *** sublimity-map (minimap, experimental)
 **** sublimity-map-size, fraction, text-scale
 

--- a/sublimity-scroll.el
+++ b/sublimity-scroll.el
@@ -49,6 +49,11 @@
   :type 'integer
   :group 'sublimity)
 
+(defcustom sublimity-scroll-vertical-frame-delay 0
+  "Additional time to pause between each scroll step"
+  :type 'number
+  :group 'sublimity)
+
 (defcustom sublimity-scroll-hide-cursor t
   "When non-nil, hide cursor while scrolling."
   :type 'boolean
@@ -107,7 +112,8 @@
       (dolist (speed speeds)
         (sublimity-scroll--vscroll speed)
         (force-window-update (selected-window))
-        (redisplay)))))
+        (redisplay)
+        (sleep-for sublimity-scroll-vertical-frame-delay)))))
 
 (defun sublimity-scroll--hscroll-effect (cols)
   (save-excursion


### PR DESCRIPTION
Add `sublimity-scroll-vertical-frame-delay` between scroll steps.
Closes #57