### PR TITLE
Make vertical re-centering customizable

### DIFF
--- a/sublimity.el
+++ b/sublimity.el
@@ -87,6 +87,11 @@
   :type '(repeat symbol)
   :group 'sublimity)
 
+(defcustom sublimity-vertical-recenter t
+  "When non-nil, recenter cursor vertically when it leaves the screen."
+  :type 'boolean
+  :group 'sublimity)
+
 ;; + minor mode
 
 (defvar sublimity-auto-hscroll-mode nil)
@@ -173,9 +178,10 @@
       (when handle-scroll
         (let (deactivate-mark)
           ;; do vscroll
-          (with-selected-window sublimity--prev-wnd
-            (when (not (pos-visible-in-window-p))
-              (recenter)))
+          (if sublimity-vertical-recenter
+              (with-selected-window sublimity--prev-wnd
+                (when (not (pos-visible-in-window-p))
+                  (recenter))))
           ;; do hscroll
           (when (and sublimity-auto-hscroll-mode
                      (or truncate-lines


### PR DESCRIPTION
I broke this section out into a customizable variable, so not every movement off the screen causes a vertical re-centering. I prefer that behavior only on certain commands which I can set myself.